### PR TITLE
add a proxy, fetch example grib2 from it

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -32,13 +32,8 @@ var DATA = {
         Filename: "prototype"
 };
 
-// var link = "test/CMC_hrdps_east_ABSV_ISBL_0700_ps2.5km_2019070912_P000-00.grib2";
-// var link = "test/CMC_reg_TMP_TGL_2_ps10km_2019070818_P000.grib2";
-var link = "test/CMC_hrdps_east_TMP_TGL_2_ps2.5km_2019070912_P020-00.grib2";
-// var link = "http://dd.weather.gc.ca/model_gem_regional/10km/grib2/18/000/CMC_reg_TMP_TGL_2_ps10km_2019070818_P000.grib2";
-//var link = "https://nomads.ncep.noaa.gov/cgi-bin/filter_hrrr_2d.pl?file=hrrr.t00z.wrfsfcf00.grib2&lev_2_m_above_ground=on&var_TMP=on&leftlon=0&rightlon=360&toplat=90&bottomlat=-90&showurl=&dir=%2Fhrrr.20190709%2Fconus";
-//var link = "./temp/grib2/hrrr.grib2" // should save a NCEP grib2 file from grib filter links here https://nomads.ncep.noaa.gov/
-
+var link = 'https://dd.weather.gc.ca/model_gem_global/25km/grib2/lat_lon/00/003/CMC_glb_TMP_ISBL_1000_latlon.24x.24_2019070900_P003.grib2'
+link = link.replace('https://dd.weather.gc.ca/', 'http://localhost:3000/')
 DATA.numMembers = 1; // i.e. deterministic
 
 var BaseFolder = ".";

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "watchify browser.js -o build/bundle.js -v"
+    "dev": "watchify browser.js -o build/bundle.js -v",
+    "proxy": "node server/proxy.js"
   },
   "repository": {
     "type": "git",

--- a/server/proxy.js
+++ b/server/proxy.js
@@ -1,0 +1,75 @@
+/** If you want to use the local development environment with the dev backend,
+ * this will create a proxy so you won't run into CORS issues.
+ * It accepts the following command line parameters:
+ * - port the port where the proxy will listen
+ * - target the DEV backend target to contact.
+ * Example: If you set the port to 3000 and target to https://dev.nibo.ai then
+ * your actual "resourceBaseUrl" in NiboSettings should be http://localhost:3000/api/v1
+ */
+ // Define the command line options
+const optionDefinitions = [
+	{ name: "port", alias: "p", type: Number, defaultValue: 3000 },
+	{ name: "target", alias: "t", type: String, defaultValue: "https://dd.meteo.gc.ca/" }
+];
+commandLineArgs = require("command-line-args");
+// parse command line options
+const options = commandLineArgs(optionDefinitions);
+
+// Start the proxy
+console.log("Start proxy on port", options.port, "for", options.target);
+var http = require("http"), httpProxy = require("http-proxy");
+
+// Create a proxy server with custom application logic
+var proxy = httpProxy.createProxyServer({});
+var sendError = function(res, err) {
+	return res.status(500).send({
+		 error: err,
+		 message: "An error occured in the proxy"
+	});
+};
+
+// error handling
+proxy.on("error", function (err, req, res) {
+	sendError(res, err);
+});
+
+var enableCors = function(req, res) {
+	if (req.headers['access-control-request-method']) {
+		res.setHeader('access-control-allow-methods', req.headers['access-control-request-method']);
+	}
+
+	if (req.headers['access-control-request-headers']) {
+		res.setHeader('access-control-allow-headers', req.headers['access-control-request-headers']);
+	}
+
+	if (req.headers.origin) {
+		res.setHeader('access-control-allow-origin', req.headers.origin);
+		res.setHeader('access-control-allow-credentials', 'true');
+	}
+};
+
+// set header for CORS
+proxy.on("proxyRes", function(proxyRes, req, res) {
+	enableCors(req, res);
+});
+
+var server = http.createServer(function(req, res) {
+	// You can define here your custom logic to handle the request
+	// and then proxy the request.
+	if (req.method === 'OPTIONS') {
+		enableCors(req, res);
+		res.writeHead(200);
+		res.end();
+		return;
+	}
+
+	proxy.web(req, res, {
+		target: options.target,
+		secure: true,
+		changeOrigin: true
+	}, function(err) {
+		sendError(res, err);
+	});
+});
+
+server.listen(options.port);

--- a/server/proxy.js
+++ b/server/proxy.js
@@ -1,3 +1,5 @@
+// FROM: https://gist.githubusercontent.com/beradrian/e3cf8c7ec83cca45c89556404445bde5/raw/caed9db788d3668299ca7d99923f1c59c8df33c6/proxy.js
+
 /** If you want to use the local development environment with the dev backend,
  * this will create a proxy so you won't run into CORS issues.
  * It accepts the following command line parameters:


### PR DESCRIPTION
To start the proxy, type `npm run proxy` then CORS will work